### PR TITLE
[prod] Update Dockerfile to working conditions and elaboration in README on Docker usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ RUN pip install -r /tmp/requirements.txt
 WORKDIR /opt/jvm-loss
 COPY . /opt/jvm-loss/
 
-CMD ["python", "/opt/jvm-loss/mailclient.py"]
+ENTRYPOINT ["python", "/opt/jvm-loss/mailclient.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM python:3
-COPY requirements.txt /opt/app/requirements.txt
-WORKDIR /opt/app
-RUN pip install -r requirements.txt
-COPY . /opt/app/
-CMD ["python", "/opt/app/mailclient.py"]
+# First copy requirements into tmp and pip-install them to allow better caching, apparently
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install -r /tmp/requirements.txt
+# Change dir and copy source
+WORKDIR /opt/jvm-loss
+COPY . /opt/jvm-loss/
+
+CMD ["python", "/opt/jvm-loss/mailclient.py"]

--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ The JVM(Java Vending Machine) at Strandvejen may experience some loss(making cof
 
 Alternatively, build a Docker image and run it with the following commands. Note that you have to embed the authentication into the Docker `credentials.json` and `token.pickle`.
 1. `docker build --tag=jvm-loss .`
-1. `docker run --rm -it jvm-loss` The `--rm` flag removes the container upon stopping it.
+1. `docker run --name jvm-loss -it jvm-loss` Optionally specify the `--rm` flag, which removes the container upon stopping it.


### PR DESCRIPTION
This Dockerfile is now functional allowing a user to run the following to run an instance of jvm-loss under Docker.

This assumes that `credentials.json` and `token.pickle` exists in the root of the repo when invoking the commands as specified by the updated README.