### PR TITLE
[prod] Add `dev-build.sh` script for easier development under Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ RUN pip install -r /tmp/requirements.txt
 WORKDIR /opt/jvm-loss
 COPY . /opt/jvm-loss/
 
-CMD ["python", "/opt/jvm-loss/mailclient.py"]
+ENTRYPOINT ["python", "/opt/jvm-loss/mailclient.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM python:3
-COPY requirements.txt /opt/app/requirements.txt
-WORKDIR /opt/app
-RUN pip install -r requirements.txt
-COPY . /opt/app/
-CMD ["python", "/opt/app/mailclient.py"]
+# First copy requirements into tmp and pip-install them to allow better caching, apparently
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install -r /tmp/requirements.txt
+# Change dir and copy source
+WORKDIR /opt/jvm-loss
+COPY . /opt/jvm-loss/
+
+CMD ["python", "/opt/jvm-loss/mailclient.py"]

--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ The JVM(Java Vending Machine) at Strandvejen may experience some loss(making cof
 
 Alternatively, build a Docker image and run it with the following commands. Note that you have to embed the authentication into the Docker `credentials.json` and `token.pickle`.
 1. `docker build --tag=jvm-loss .`
-1. `docker run --rm -it jvm-loss` The `--rm` flag removes the container upon stopping it.
+1. `docker run --name jvm-loss -it jvm-loss` Optionally specify the `--rm` flag, which removes the container upon stopping it.

--- a/dev-build.sh
+++ b/dev-build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Pull, exiting if failure
+git pull || exit 1
+
+# FIXME, remove previous images? :latest should be sufficient
+printf "### VCS cleared. Continuing flow\n"
+
+# Build new image from Dockerfile
+printf "### Building new 'cogi/jvm-loss' image\n"
+sudo docker build -t cogi/jvm-loss .
+
+# Stop running images based on 'cogi/jvm-loss'
+printf "### Stopping all containers which are ancestors of 'cogi/jvm-loss'\n" 
+sudo docker ps -qf ancestor=cogi/jvm-loss | xargs -r sudo docker stop
+
+# Forcefully remove any containers named 'jvm-loss'
+printf "### Removing any container named 'jvm-loss'\n"
+sudo docker ps -qaf name=jvm-loss | xargs -r sudo docker rm -f 
+
+# Run and attach to new image, to detach without killing process use [Ctrl+p] [Ctrl+q]
+printf "### Running new 'cogi/jvm-loss' image\n"
+sudo docker run --name jvm-loss -it cogi/jvm-loss:latest

--- a/dev-build.sh
+++ b/dev-build.sh
@@ -15,9 +15,9 @@ printf "### Stopping all containers which are ancestors of 'cogi/jvm-loss'\n"
 sudo docker ps -qf ancestor=cogi/jvm-loss | xargs -r sudo docker stop
 
 # Forcefully remove any containers named 'jvm-loss'
-printf "### Removing any container named 'jvm-loss'\n"
-sudo docker ps -qaf name=jvm-loss | xargs -r sudo docker rm -f 
+printf "### Removing any container named 'jvm-loss-dev'\n"
+sudo docker ps -qaf name=jvm-loss-dev | xargs -r sudo docker rm -f 
 
 # Run and attach to new image, to detach without killing process use [Ctrl+p] [Ctrl+q]
 printf "### Running new 'cogi/jvm-loss' image\n"
-sudo docker run --name jvm-loss -it cogi/jvm-loss:latest
+sudo docker run --name jvm-loss-dev -it cogi/jvm-loss:latest


### PR DESCRIPTION
Somewhat depends on #24 as that contains a working Dockerfile. This branch does have #24 in its history.

`dev-build.sh` should help immensely with quick testing of the project running under Docker. It maintains a single running 'jvm-loss' instance and uses the name `jvm-loss-dev` to differentiate containers built with this procedure from others.

Note that the scripts run the newly built image in interactive mode. To detach from the ptty without stopping the container, use the keyboard shortcut: `[Ctrl+p] [Ctrl+q]`